### PR TITLE
Correct requirements for zip / city / state

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ class AccountApproved extends Notification
 ### Available Postcard methods
 
 - `fromAddress()` Address of the sender.
-- `toAddress()` Address of teh receiver.
+- `toAddress()` Address of the receiver.
 - `country()` Set the country. `US` is default.
-- `city()` required if city is `US`.
-- `state()` required if city is `US`.
-- `zip()` required if city is `US`.
+- `city()` required if country is `US`.
+- `state()` required if country is `US`.
+- `zip()` required if country is `US`.
 - `front()` A 4.25"x6.25" or 6.25"x11.25" image to use as the front of the postcard.
 - `message()` The message at the back of the card.
 


### PR DESCRIPTION
I also fixed a typo.

City / State / Zip are only required if the address's country is US, per the docs here: 
https://lob.com/docs#addresses_create

(I presume this was just a typo or a mistake, since you guys did have the requirement, just for the wrong field :) )

Thanks!